### PR TITLE
chore(checkstyle): configure static code analysis (#6)

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+
+    <property name="charset" value="UTF-8"/>
+
+    <module name="TreeWalker">
+
+        <!-- Naming -->
+        <module name="TypeName"/>
+        <module name="MethodName"/>
+        <module name="ParameterName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+
+        <!-- Imports -->
+        <module name="UnusedImports"/>
+        <module name="AvoidStarImport"/>
+
+        <!-- Javadocs -->
+        <module name="JavadocType"/>
+        <module name="JavadocMethod"/>
+
+        <!-- Classes -->
+        <module name="FinalClass"/>
+
+        <!-- Misc -->
+        <module name="EmptyBlock"/>
+        <module name="NeedBraces"/>
+    </module>
+
+    <!-- File Length -->
+    <module name="LineLength">
+        <property name="max" value="100"/>
+    </module>
+
+</module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -34,7 +34,7 @@
         <module name="NeedBraces"/>
     </module>
 
-    <!-- File Length -->
+    <!-- Line Length -->
     <module name="LineLength">
         <property name="max" value="100"/>
     </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -21,8 +21,10 @@
         <module name="AvoidStarImport"/>
 
         <!-- Javadocs -->
+        <!--
         <module name="JavadocType"/>
         <module name="JavadocMethod"/>
+        -->
 
         <!-- Classes -->
         <module name="FinalClass"/>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,30 @@
                 </executions>
             </plugin>
 
+            <!-- CHECKSTYLE -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
Add static code analysis rules that enforce coding standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added project-wide code style enforcement using Checkstyle (UTF-8 encoding), including naming, import rules (no unused/star imports), and structural formatting checks, with a 100-character line length limit.
  * Updated the build to run style checks during the early build phase, print violations to the console, and fail the build on Checkstyle errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->